### PR TITLE
Added exit icon, top left corner

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
       href="https://fonts.googleapis.com/css?family=Karla:400,700&display=swap"
       rel="stylesheet"
     />
+    <script type="module" src="https://unpkg.com/ionicons@5.0.0/dist/ionicons/ionicons.esm.js"></script>
     <title>Nimbus Chat</title>
   </head>
   <body>

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@
         <img class="icon" src="@/assets/help.svg" alt="help" @click="status = 'suggesting'" />
       </nav>
       <transition name="roll">
-        <query-examples v-if="status === 'suggesting'" @select="useExample" />
+        <query-examples v-if="status === 'suggesting'" @select="useExample" @close="closeExample"/>
       </transition>
 
       <div class="messages" ref="messages">
@@ -114,6 +114,9 @@ export default {
       //Not great practice, but its better performance than a watcher
       this.$refs.composer.$refs.messageInput.innerText = text;
       this.textField = text;
+      this.status = "chatting";
+    },
+    closeExample() {
       this.status = "chatting";
     }
   }

--- a/src/components/QueryExamples.vue
+++ b/src/components/QueryExamples.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="query-examples">
     <h2>Stuff Nimbus Knows</h2>
+    <ion-icon
+      class="close-icon"
+      name="close-circle"
+      @click="requestClose">
+    </ion-icon>
     <ul class="example-list">
       <li
         v-for="example in examples"
@@ -23,6 +28,9 @@ export default {
   methods: {
     selectExample(e) {
       this.$emit("select", e.target.innerText);
+    },
+    requestClose() {
+      this.$emit("close");
     }
   }
 };
@@ -39,9 +47,15 @@ export default {
   width: 100%;
   height: 100%;
   overflow-y: scroll;
-
   h2 {
     text-align: center;
+  }
+  .close-icon {
+    position: fixed;
+    top: 0;
+    font-size: 2em;
+    cursor: pointer;
+    padding: 5px;
   }
   .example-list {
     list-style: none;

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import Vue from "vue";
 import App from "./App.vue";
 import "@/modules/axios-config.js";
 Vue.config.productionTip = false;
+Vue.config.ignoredElements = [/^ion-/];
 
 new Vue({
   render: h => h(App)


### PR DESCRIPTION
I used the "close-circle" icon from Ionicons as an exit button for the query examples pop-up. The button is in the top left corner where it won't overlap with examples while scrolling. Aesthetically, I'd prefer it to be on the right side, but I was having issues with overlap. I believe it functions as desired, however! :)